### PR TITLE
Use https: protocol instead of deprecated git: protocol

### DIFF
--- a/index.html
+++ b/index.html
@@ -76,7 +76,7 @@ the Ninja binary</a> or <a href="https://github.com/ninja-build/ninja/wiki/Pre-b
 it in your system's package manager</a>.</p>
 
 <p>Or, build from source:<br>
-<pre>$ git clone git://github.com/ninja-build/ninja.git && cd ninja
+<pre>$ git clone https://github.com/ninja-build/ninja.git && cd ninja
 $ git checkout release
 $ cat README.md</pre></p>
 


### PR DESCRIPTION
👋 GitHub no longer supports the `git://` protocol for cloning, this will produce errors. Instead, use the HTTPS protocol. See the [GitHub blog post](https://github.blog/2021-09-01-improving-git-protocol-security-github/) for more information.